### PR TITLE
docs: add backend API documentation

### DIFF
--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -1,0 +1,67 @@
+# Admin API
+
+Administrative endpoints for managing cameras, streams, and encoder roles.
+
+## Cameras
+
+### List Cameras
+`GET /api/admin/cameras`
+
+Returns all cameras with configuration and stream metadata.
+
+### Create Camera
+`POST /api/admin/cameras`
+
+Body fields: `name`, `rtsp_url`, optional `retention_days`.
+
+### Update Camera
+`PUT /api/admin/cameras/{cam_id}`
+
+Updates camera settings such as RTSP URL, retention, and encoder quality.
+
+### Delete Camera
+`DELETE /api/admin/cameras/{cam_id}`
+
+Stops FFmpeg processes and removes the camera.
+
+### Update Role Configuration
+`PUT /api/admin/cameras/{cam_id}/roles`
+
+Adjusts stream selection and modes for grid, medium, high, and recording roles and retention.
+
+### Start or Stop Camera
+`POST /api/admin/cameras/{cam_id}/start`
+
+`POST /api/admin/cameras/{cam_id}/stop`
+
+Starts or stops all FFmpeg processes for the camera.
+
+### Camera Status
+`GET /api/admin/cameras/{cam_id}/status`
+
+Returns running flags for each role.
+
+## Streams
+
+### List Streams
+`GET /api/admin/cameras/{cam_id}/streams`
+
+### Add Stream
+`POST /api/admin/cameras/{cam_id}/streams`
+
+Body fields: `name`, `rtsp_url`.
+
+### Probe Stream
+`POST /api/admin/cameras/{cam_id}/streams/{stream_id}/probe`
+
+Runs ffprobe to populate stream metadata.
+
+## On-demand Roles
+
+Endpoints to control specific encoder roles:
+
+- `POST /api/admin/cameras/{cam_id}/grid/start`
+- `POST /api/admin/cameras/{cam_id}/medium/start`
+- `POST /api/admin/cameras/{cam_id}/medium/stop`
+- `POST /api/admin/cameras/{cam_id}/high/start`
+- `POST /api/admin/cameras/{cam_id}/high/stop`

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -1,0 +1,25 @@
+# Client API
+
+Endpoints for frontend clients to discover cameras and retrieve recordings. Authentication is currently not enforced.
+
+## List Cameras
+
+`GET /api/cameras`
+
+Returns an object containing all cameras and the relative URLs to their low and high HLS feeds.
+
+## List Recordings for a Date
+
+`GET /api/cameras/{cam_id}/recordings/{date}`
+
+Lists recording files for the specified camera on the given `YYYY-MM-DD` date. Each entry includes:
+
+- `path` – API path to the MP4 file.
+- `start_ts` – recording start timestamp in epoch seconds.
+- `size_bytes` – file size in bytes.
+
+## Fetch a Recording File
+
+`GET /api/recordings/{camera}/{date}/{hour}/{filename}`
+
+Streams or downloads the requested MP4 recording.

--- a/docs/client-api.md
+++ b/docs/client-api.md
@@ -8,6 +8,21 @@ Endpoints for frontend clients to discover cameras and retrieve recordings. Auth
 
 Returns an object containing all cameras and the relative URLs to their low and high HLS feeds.
 
+**Sample response**
+
+```json
+{
+  "front": {
+    "low": "/streams/front-low.m3u8",
+    "high": "/streams/front-high.m3u8"
+  },
+  "garage": {
+    "low": "/streams/garage-low.m3u8",
+    "high": "/streams/garage-high.m3u8"
+  }
+}
+```
+
 ## List Recordings for a Date
 
 `GET /api/cameras/{cam_id}/recordings/{date}`
@@ -18,8 +33,34 @@ Lists recording files for the specified camera on the given `YYYY-MM-DD` date. E
 - `start_ts` – recording start timestamp in epoch seconds.
 - `size_bytes` – file size in bytes.
 
+**Sample response**
+
+```json
+[
+  {
+    "path": "/api/recordings/front/2024-04-06/00/front-000000.mp4",
+    "start_ts": 1712361600,
+    "size_bytes": 1048576
+  },
+  {
+    "path": "/api/recordings/front/2024-04-06/01/front-010000.mp4",
+    "start_ts": 1712365200,
+    "size_bytes": 2097152
+  }
+]
+```
+
 ## Fetch a Recording File
 
 `GET /api/recordings/{camera}/{date}/{hour}/{filename}`
 
 Streams or downloads the requested MP4 recording.
+
+**Sample response**
+
+```http
+HTTP/1.1 200 OK
+Content-Type: video/mp4
+
+<binary mp4 data>
+```


### PR DESCRIPTION
## Summary
- Document client-facing API for listing cameras and accessing recordings
- Document admin API for camera management, stream control, and role operations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba664f284c83278379598cb1098f8d