### PR TITLE
Expose role URLs in camera list endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -317,8 +317,11 @@ def client_list_cameras(request: Request, session: Session = Depends(get_session
         {
           "id": "1",
           "name": "Front Door",
-          "low_url":  "http://<server>/media/live/<camera>/low/index.m3u8",
-          "high_url": "http://<server>/media/live/<camera>/high/index.m3u8"
+          "urls": {
+            "grid":   "http://<server>/media/live/<camera>/grid/index.m3u8",
+            "medium": "http://<server>/media/live/<camera>/medium/index.m3u8",
+            "high":   "http://<server>/media/live/<camera>/high/index.m3u8"
+          }
         },
         ...
       ]
@@ -328,14 +331,14 @@ def client_list_cameras(request: Request, session: Session = Depends(get_session
     base = str(request.base_url).rstrip("/")  # e.g. http://localhost:8091
     items: list[CameraClientItem] = []
     for cam in cams:
-        # Build absolute URLs to the existing HLS outputs
-        low  = f"/media/live/{cam.name}/low/index.m3u8"
-        high = f"/media/live/{cam.name}/high/index.m3u8"
+        urls = {
+            role: f"{base}/media/live/{cam.name}/{role}/index.m3u8"
+            for role in ("grid", "medium", "high")
+        }
         items.append(CameraClientItem(
             id=str(cam.id),
             name=cam.name,
-            low_url=low,
-            high_url=high,
+            urls=urls,
         ))
     return CameraClientList(cameras=items)
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,5 @@
 # backend/app/schemas.py
-from typing import Optional, List
+from typing import Optional, List, Dict
 from pydantic import BaseModel
 from .models import RoleMode  # Enum: "auto" | "manual" | "disabled"
 
@@ -87,8 +87,7 @@ class CameraAdminOut(BaseModel):
 class CameraClientItem(BaseModel):
     id: str
     name: str
-    low_url: str
-    high_url: str
+    urls: Dict[str, str]  # role -> url
 
 class CameraClientList(BaseModel):
     cameras: List[CameraClientItem]

--- a/clients/ios/HomeCam/Models/Camera.swift
+++ b/clients/ios/HomeCam/Models/Camera.swift
@@ -3,13 +3,10 @@ import Foundation
 struct Camera: Identifiable, Decodable, Hashable {
     let id: String
     let name: String
-    let lowURL: URL
-    let highURL: URL
+    let urls: [String: URL]
 
-    enum CodingKeys: String, CodingKey {
-        case id, name
-        case lowURL = "low_url"
-        case highURL = "high_url"
+    func url(for role: String) -> URL? {
+        return urls[role]
     }
 }
 

--- a/clients/ios/HomeCam/Networking/APIClient.swift
+++ b/clients/ios/HomeCam/Networking/APIClient.swift
@@ -6,7 +6,7 @@ final class APIClient {
     private init() {}
 
     func fetchCameras(serverBase: URL) async throws -> [Camera] {
-        // Expecting: GET {serverBase}/api/cameras -> { "cameras": [ {id,name,low_url,high_url}, ... ] }
+        // Expecting: GET {serverBase}/api/cameras -> { "cameras": [ {id,name,urls:{role:url,...}}, ... ] }
         let url = serverBase.appendingPathComponent("api/cameras")
         var req = URLRequest(url: url)
         req.timeoutInterval = 15

--- a/clients/ios/HomeCam/ViewModels/CamerasViewModel.swift
+++ b/clients/ios/HomeCam/ViewModels/CamerasViewModel.swift
@@ -41,7 +41,8 @@ final class CamerasViewModel: ObservableObject {
         gridPlayers.removeAll()
 
         for cam in cams {
-            let p = AVPlayer(url: cam.lowURL)
+            guard let url = cam.urls["grid"] else { continue }
+            let p = AVPlayer(url: url)
             p.isMuted = true
             // Auto-play
             p.play()

--- a/clients/ios/HomeCam/Views/CameraDetailView.swift
+++ b/clients/ios/HomeCam/Views/CameraDetailView.swift
@@ -31,10 +31,12 @@ struct CameraDetailView: View {
         }
         .onAppear {
             // Build the high-res player fresh (keeps grid paused)
-            let p = AVPlayer(url: camera.highURL)
-            p.automaticallyWaitsToMinimizeStalling = true
-            p.isMuted = false
-            player = p
+            if let url = camera.urls["high"] ?? camera.urls["medium"] ?? camera.urls["grid"] {
+                let p = AVPlayer(url: url)
+                p.automaticallyWaitsToMinimizeStalling = true
+                p.isMuted = false
+                player = p
+            }
         }
         .onDisappear {
             player?.pause()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,5 @@
 // Unified API client with separate client vs admin surfaces.
-// CLIENT: /api/cameras returns { cameras: [...] } with low_url/high_url
+// CLIENT: /api/cameras returns { cameras: [...] } with URLs keyed by role name
 // ADMIN: camera CRUD, streams, roles, and medium/high on-demand controls.
 
 const API = {


### PR DESCRIPTION
## Summary
- return URLs keyed by stream role from /api/cameras instead of low/high fields
- adjust client schemas and Swift app to consume the new mapping
- document role-based URLs in frontend API helper

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba67aaf4b08327b19a7244b653497f