### PR TITLE
Return relative media URLs for camera API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,5 @@
 # backend/app/main.py
-from fastapi import FastAPI, Depends, HTTPException, Request
+from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
@@ -309,7 +309,7 @@ def start_grid(cam_id: int, session: Session = Depends(get_session)):
 # ----------------------------- Client API (no RTSP) -------------------------------
 
 @app.get("/api/cameras", response_model=CameraClientList)
-def client_list_cameras(request: Request, session: Session = Depends(get_session)):
+def client_list_cameras(session: Session = Depends(get_session)):
     """
     Returns:
     {
@@ -318,9 +318,9 @@ def client_list_cameras(request: Request, session: Session = Depends(get_session
           "id": "1",
           "name": "Front Door",
           "urls": {
-            "grid":   "http://<server>/media/live/<camera>/grid/index.m3u8",
-            "medium": "http://<server>/media/live/<camera>/medium/index.m3u8",
-            "high":   "http://<server>/media/live/<camera>/high/index.m3u8"
+            "grid":   "/media/live/<camera>/grid/index.m3u8",
+            "medium": "/media/live/<camera>/medium/index.m3u8",
+            "high":   "/media/live/<camera>/high/index.m3u8"
           }
         },
         ...
@@ -328,11 +328,10 @@ def client_list_cameras(request: Request, session: Session = Depends(get_session
     }
     """
     cams = session.query(Camera).order_by(Camera.id.asc()).all()
-    base = str(request.base_url).rstrip("/")  # e.g. http://localhost:8091
     items: list[CameraClientItem] = []
     for cam in cams:
         urls = {
-            role: f"{base}/media/live/{cam.name}/{role}/index.m3u8"
+            role: f"/media/live/{cam.name}/{role}/index.m3u8"
             for role in ("grid", "medium", "high")
         }
         items.append(CameraClientItem(

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -59,6 +59,12 @@ def test_camera_crud(api_client):
     assert len(cams) == 1
     assert cams[0]["id"] == cam_id
 
+    # Client API should expose relative URLs
+    resp = client.get("/api/cameras")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["cameras"][0]["urls"]["grid"] == f"/media/live/{payload['name']}/grid/index.m3u8"
+
     # Delete the camera
     resp = client.delete(f"/api/admin/cameras/{cam_id}")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- update `/api/cameras` endpoint to emit relative paths
- adjust tests to verify relative media URLs

## Testing
- `pytest backend/tests/test_api.py::test_camera_crud -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf3e55ba4832780bcac0f8c3074bd