### PR TITLE
fix: enforce square pixels for grid streams

### DIFF
--- a/backend/app/ffmpeg_manager.py
+++ b/backend/app/ffmpeg_manager.py
@@ -287,9 +287,13 @@ class FFmpegManager:
             "-maxrate", "4000k" if role != "grid" else "1200k",
             "-bufsize", "4000k" if role != "grid" else "1200k",
         ]
-        vf = []
+        # Always force square pixels. When scale_w/scale_h are provided (auto mode)
+        # apply scaling then set SAR=1; otherwise just set SAR to 1 while keeping
+        # original resolution for manual mode streams.
         if scale_w and scale_h:
-            vf = ["-vf", f"scale={scale_w}:{scale_h}"]  # only used for grid/auto
+            vf = ["-vf", f"scale={scale_w}:{scale_h},setsar=1"]
+        else:
+            vf = ["-vf", "setsar=1"]
 
         audio = ["-an"] if role == "grid" else ["-c:a", "aac", "-ar", "44100", "-ac", "1"]
 


### PR DESCRIPTION
## Summary
- ensure HLS grid streams always use square pixels to prevent width oscillation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbb9d291b8832781486432207b4ea9