### PR TITLE
Renew lease on stream requests

### DIFF
--- a/backend/app/lease_static.py
+++ b/backend/app/lease_static.py
@@ -33,11 +33,9 @@ class LeaseRenewStaticFiles(StaticFiles):
                     if cam_id is not None:
                         key = (cam_id, role)
                         lease_id = self._leases.get(key)
-                        if lease_id is None:
+                        if lease_id is None or not ffmpeg_manager.renew_lease(cam_id, role, lease_id):
                             lease_id = ffmpeg_manager.acquire_lease(cam_id, role)
                             self._leases[key] = lease_id
-                        else:
-                            ffmpeg_manager.renew_lease(cam_id, role, lease_id)
         except Exception:  # pragma: no cover - best effort logging
             logger.exception("lease renew error")
 

--- a/backend/app/lease_static.py
+++ b/backend/app/lease_static.py
@@ -1,21 +1,23 @@
 import logging
-from typing import Optional
+from typing import Optional, Dict, Tuple
 
 from starlette.staticfiles import StaticFiles
-from urllib.parse import parse_qs
 
 from .ffmpeg_manager import ffmpeg_manager
 
 logger = logging.getLogger(__name__)
 
 class LeaseRenewStaticFiles(StaticFiles):
-    """StaticFiles subclass that renews ffmpeg leases on media requests.
+    """StaticFiles subclass that manages ffmpeg leases on media requests.
 
-    When a client requests a medium or high quality stream segment or playlist,
-    a ``lease`` query parameter may be supplied.  This handler will renew the
-    corresponding lease so that the stream stays alive while it is actively
-    being consumed.
+    For medium and high quality streams, the first request will automatically
+    acquire a lease for the stream.  Subsequent requests will renew that lease
+    so the underlying ffmpeg process remains active while content is served.
     """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._leases: Dict[Tuple[int, str], str] = {}
 
     async def get_response(self, path: str, scope):  # type: ignore[override]
         # Serve the actual file first
@@ -27,11 +29,14 @@ class LeaseRenewStaticFiles(StaticFiles):
                 cam_name = parts[1]
                 role = parts[2]
                 if role in {"medium", "high"}:
-                    qs = parse_qs(scope.get("query_string", b"").decode())
-                    lease_id = qs.get("lease", [None])[0]
-                    if lease_id:
-                        cam_id = _cam_id_by_name(cam_name)
-                        if cam_id is not None:
+                    cam_id = _cam_id_by_name(cam_name)
+                    if cam_id is not None:
+                        key = (cam_id, role)
+                        lease_id = self._leases.get(key)
+                        if lease_id is None:
+                            lease_id = ffmpeg_manager.acquire_lease(cam_id, role)
+                            self._leases[key] = lease_id
+                        else:
                             ffmpeg_manager.renew_lease(cam_id, role, lease_id)
         except Exception:  # pragma: no cover - best effort logging
             logger.exception("lease renew error")

--- a/backend/app/lease_static.py
+++ b/backend/app/lease_static.py
@@ -1,0 +1,47 @@
+import logging
+from typing import Optional
+
+from starlette.staticfiles import StaticFiles
+from urllib.parse import parse_qs
+
+from .ffmpeg_manager import ffmpeg_manager
+
+logger = logging.getLogger(__name__)
+
+class LeaseRenewStaticFiles(StaticFiles):
+    """StaticFiles subclass that renews ffmpeg leases on media requests.
+
+    When a client requests a medium or high quality stream segment or playlist,
+    a ``lease`` query parameter may be supplied.  This handler will renew the
+    corresponding lease so that the stream stays alive while it is actively
+    being consumed.
+    """
+
+    async def get_response(self, path: str, scope):  # type: ignore[override]
+        # Serve the actual file first
+        response = await super().get_response(path, scope)
+
+        try:
+            parts = path.split("/")
+            if len(parts) >= 3 and parts[0] == "live":
+                cam_name = parts[1]
+                role = parts[2]
+                if role in {"medium", "high"}:
+                    qs = parse_qs(scope.get("query_string", b"").decode())
+                    lease_id = qs.get("lease", [None])[0]
+                    if lease_id:
+                        cam_id = _cam_id_by_name(cam_name)
+                        if cam_id is not None:
+                            ffmpeg_manager.renew_lease(cam_id, role, lease_id)
+        except Exception:  # pragma: no cover - best effort logging
+            logger.exception("lease renew error")
+
+        return response
+
+
+def _cam_id_by_name(name: str) -> Optional[int]:
+    """Helper to resolve cam_id from name using ffmpeg_manager state."""
+    for cid, cname in ffmpeg_manager._cam_names.items():  # type: ignore[attr-defined]
+        if cname == name:
+            return cid
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,6 @@
 # backend/app/main.py
 from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 import os
 import logging
@@ -26,6 +25,7 @@ from .schemas import (
     RecordingFile,
 )
 from .ffmpeg_manager import ffmpeg_manager
+from .lease_static import LeaseRenewStaticFiles
 from .recordings import list_recordings
 from .config import settings, MEDIA_ROOT, LIVE_DIR, REC_DIR
 from .retention import run_retention_loop
@@ -71,7 +71,7 @@ REC_DIR.mkdir(parents=True, exist_ok=True)
 Base.metadata.create_all(bind=engine)
 
 # Serve /media (used by both dev and docker)
-app.mount("/media", StaticFiles(directory=str(MEDIA_ROOT)), name="media")
+app.mount("/media", LeaseRenewStaticFiles(directory=str(MEDIA_ROOT)), name="media")
 
 # Background retention loop (daily)
 threading.Thread(target=run_retention_loop, args=(get_session,), daemon=True).start()

--- a/backend/tests/test_lease_renew.py
+++ b/backend/tests/test_lease_renew.py
@@ -1,0 +1,32 @@
+import sys
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.append('backend')
+from app.lease_static import LeaseRenewStaticFiles
+from app.ffmpeg_manager import ffmpeg_manager
+
+
+def test_lease_renew_on_medium_request(tmp_path, monkeypatch):
+    media_root = tmp_path / "media"
+    live_dir = media_root / "live" / "cam1" / "medium"
+    live_dir.mkdir(parents=True)
+    (live_dir / "index.m3u8").write_text("dummy")
+
+    # prepare manager mapping
+    ffmpeg_manager._cam_names[1] = "cam1"  # type: ignore[attr-defined]
+
+    called = {}
+
+    def fake_renew(cam_id, role, lease_id):
+        called["args"] = (cam_id, role, lease_id)
+
+    monkeypatch.setattr(ffmpeg_manager, "renew_lease", fake_renew)
+
+    app = FastAPI()
+    app.mount("/media", LeaseRenewStaticFiles(directory=str(media_root)), name="media")
+
+    client = TestClient(app)
+    resp = client.get("/media/live/cam1/medium/index.m3u8?lease=abc123")
+    assert resp.status_code == 200
+    assert called["args"] == (1, "medium", "abc123")

--- a/backend/tests/test_lease_renew.py
+++ b/backend/tests/test_lease_renew.py
@@ -24,6 +24,7 @@ def test_auto_acquire_and_renew(tmp_path, monkeypatch):
 
     def fake_renew(cam_id, role, lease_id):
         calls["renew"].append((cam_id, role, lease_id))
+        return True
 
     monkeypatch.setattr(ffmpeg_manager, "acquire_lease", fake_acquire)
     monkeypatch.setattr(ffmpeg_manager, "renew_lease", fake_renew)
@@ -41,3 +42,45 @@ def test_auto_acquire_and_renew(tmp_path, monkeypatch):
     assert resp2.status_code == 200
     assert calls["acquire"] == [(1, "medium")]
     assert calls["renew"] == [(1, "medium", "lease123")]
+
+
+def test_reacquire_after_expired_lease(tmp_path, monkeypatch):
+    media_root = tmp_path / "media"
+    live_dir = media_root / "live" / "cam1" / "medium"
+    live_dir.mkdir(parents=True)
+    (live_dir / "index.m3u8").write_text("dummy")
+
+    ffmpeg_manager._cam_names[1] = "cam1"  # type: ignore[attr-defined]
+
+    acquire_calls = []
+    renew_calls = []
+
+    acquire_ids = iter(["lease1", "lease2"])
+
+    def fake_acquire(cam_id, role):
+        lid = next(acquire_ids)
+        acquire_calls.append((cam_id, role, lid))
+        return lid
+
+    renew_results = iter([False, True])
+
+    def fake_renew(cam_id, role, lease_id):
+        renew_calls.append((cam_id, role, lease_id))
+        return next(renew_results)
+
+    monkeypatch.setattr(ffmpeg_manager, "acquire_lease", fake_acquire)
+    monkeypatch.setattr(ffmpeg_manager, "renew_lease", fake_renew)
+
+    app = FastAPI()
+    app.mount("/media", LeaseRenewStaticFiles(directory=str(media_root)), name="media")
+
+    client = TestClient(app)
+    client.get("/media/live/cam1/medium/index.m3u8")
+    client.get("/media/live/cam1/medium/index.m3u8")
+    client.get("/media/live/cam1/medium/index.m3u8")
+
+    assert acquire_calls == [(1, "medium", "lease1"), (1, "medium", "lease2")]
+    assert renew_calls == [
+        (1, "medium", "lease1"),
+        (1, "medium", "lease2"),
+    ]

--- a/backend/tests/test_lease_renew.py
+++ b/backend/tests/test_lease_renew.py
@@ -7,7 +7,7 @@ from app.lease_static import LeaseRenewStaticFiles
 from app.ffmpeg_manager import ffmpeg_manager
 
 
-def test_lease_renew_on_medium_request(tmp_path, monkeypatch):
+def test_auto_acquire_and_renew(tmp_path, monkeypatch):
     media_root = tmp_path / "media"
     live_dir = media_root / "live" / "cam1" / "medium"
     live_dir.mkdir(parents=True)
@@ -16,17 +16,28 @@ def test_lease_renew_on_medium_request(tmp_path, monkeypatch):
     # prepare manager mapping
     ffmpeg_manager._cam_names[1] = "cam1"  # type: ignore[attr-defined]
 
-    called = {}
+    calls = {"acquire": [], "renew": []}
+
+    def fake_acquire(cam_id, role):
+        calls["acquire"].append((cam_id, role))
+        return "lease123"
 
     def fake_renew(cam_id, role, lease_id):
-        called["args"] = (cam_id, role, lease_id)
+        calls["renew"].append((cam_id, role, lease_id))
 
+    monkeypatch.setattr(ffmpeg_manager, "acquire_lease", fake_acquire)
     monkeypatch.setattr(ffmpeg_manager, "renew_lease", fake_renew)
 
     app = FastAPI()
     app.mount("/media", LeaseRenewStaticFiles(directory=str(media_root)), name="media")
 
     client = TestClient(app)
-    resp = client.get("/media/live/cam1/medium/index.m3u8?lease=abc123")
-    assert resp.status_code == 200
-    assert called["args"] == (1, "medium", "abc123")
+    resp1 = client.get("/media/live/cam1/medium/index.m3u8")
+    assert resp1.status_code == 200
+    assert calls["acquire"] == [(1, "medium")]
+    assert calls["renew"] == []
+
+    resp2 = client.get("/media/live/cam1/medium/index.m3u8")
+    assert resp2.status_code == 200
+    assert calls["acquire"] == [(1, "medium")]
+    assert calls["renew"] == [(1, "medium", "lease123")]


### PR DESCRIPTION
## Summary
- renew ffmpeg lease whenever medium/high stream content is requested
- serve media through custom StaticFiles subclass that renews leases
- test automatic lease renewal on medium stream requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc27a28a9c832782535ae6d63f2f98