### PR TITLE
feat(frontend): add overlay quality switch

### DIFF
--- a/frontend/src/components/CameraCard.jsx
+++ b/frontend/src/components/CameraCard.jsx
@@ -8,7 +8,7 @@ export default function CameraCard({ cam }) {
   const hlsRef = useRef(null)
   const stallTimerRef = useRef(null)
   const [status, setStatus] = useState('idle') // idle | starting | playing | error
-  const [overlay, setOverlay] = useState({ open:false, title:'', src:'' })
+  const [overlay, setOverlay] = useState({ open:false, role:'medium', src:'' })
 
   // --- tiny helpers ---
   async function headOk(url){ try { const r=await fetch(url,{method:'HEAD',cache:'no-store'}); return r.ok } catch { return false } }
@@ -25,7 +25,7 @@ export default function CameraCard({ cam }) {
     }
     const ok = await waitFor(url)
     if (!ok){ alert(`${role} stream did not become ready in time.`); return }
-    setOverlay({ open:true, title: `${cam.name} — ${role.toUpperCase()}`, src:url })
+    setOverlay({ open:true, role, src:url })
   }
 
   // --- grid thumbnail player (compact, no controls) ---
@@ -79,66 +79,37 @@ export default function CameraCard({ cam }) {
     return () => { stopWatchdog(); if (hlsRef.current){ try{ hlsRef.current.destroy() }catch{}; hlsRef.current=null } }
   }, [cam.name])
 
-  // --- icon bar handlers ---
+  // --- overlay handlers ---
   const openMedium = () => openRole('medium', `/api/admin/cameras/${cam.id}/medium/start`)
-  const openHigh   = () => openRole('high',   `/api/admin/cameras/${cam.id}/high/start`)
+  const toggleRole = () => {
+    const next = overlay.role === 'medium' ? 'high' : 'medium'
+    const start = next === 'medium'
+      ? `/api/admin/cameras/${cam.id}/medium/start`
+      : `/api/admin/cameras/${cam.id}/high/start`
+    openRole(next, start)
+  }
 
   return (
-    <div className="card" style={{borderRadius:12}}>
-      {/* compact header with two tiny icons */}
-      <div style={headerRow}>
-        <div style={title}>{cam.name}</div>
-        <div style={iconRow}>
-          <button title="Open Medium" aria-label="Open Medium" style={iconBtn} onClick={openMedium}>
-            {/* medium icon (play triangle) */}
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" role="img">
-              <path d="M8 5v14l11-7-11-7z" stroke="currentColor" strokeWidth="1.6" fill="currentColor" />
-            </svg>
-          </button>
-          <button title="Open High" aria-label="Open High" style={iconBtn} onClick={openHigh}>
-            {/* high icon (magnifier) */}
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" role="img">
-              <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="1.6"/>
-              <path d="M16.5 16.5L21 21" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
-            </svg>
-          </button>
-        </div>
-      </div>
-
+    <div style={{borderRadius:12, overflow:'hidden'}}>
       <video
         ref={videoRef}
         muted
         autoPlay
         playsInline
         preload="auto"
+        onClick={openMedium}
         // no controls to keep compact
-        style={{ width:'100%', height:260, background:'#000', display:'block' }}
+        style={{ width:'100%', height:260, background:'#000', display:'block', cursor:'pointer' }}
       />
 
       {/* Overlay player for medium/high */}
       <OverlayPlayer
         open={overlay.open}
-        title={overlay.title}
+        role={overlay.role}
         src={overlay.src}
         onClose={()=>setOverlay(o=>({ ...o, open:false }))}
+        onToggle={toggleRole}
       />
     </div>
   )
-}
-
-const headerRow = {
-  display:'flex',
-  alignItems:'center',
-  justifyContent:'space-between',
-  padding:'6px 8px',
-  borderBottom:'1px solid #1f2630'
-}
-const title = { fontSize:13, fontWeight:600, whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis', maxWidth:'70%' }
-const iconRow = { display:'flex', gap:6 }
-const iconBtn = {
-  width:28, height:28,
-  display:'grid', placeItems:'center',
-  borderRadius:8, border:'1px solid #1f2630',
-  background:'#151a21', color:'#cad5e2',
-  cursor:'pointer'
 }

--- a/frontend/src/components/OverlayPlayer.jsx
+++ b/frontend/src/components/OverlayPlayer.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Player from './Player'
 
-export default function OverlayPlayer({ open, role, src, onClose, onToggle }) {
+export default function OverlayPlayer({ open, role, src, loading, onClose, onToggle }) {
   if (!open) return null
 
   const isMedium = role === 'medium'
@@ -9,24 +9,30 @@ export default function OverlayPlayer({ open, role, src, onClose, onToggle }) {
   return (
     <div style={wrapStyle} onClick={onClose}>
       <div style={innerStyle} onClick={e => e.stopPropagation()}>
-        <Player src={src} />
-        <button
-          onClick={onToggle}
-          title={isMedium ? 'Switch to High' : 'Switch to Medium'}
-          aria-label={isMedium ? 'Switch to High' : 'Switch to Medium'}
-          style={toggleBtn}
-        >
-          {isMedium ? (
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
-              <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="1.6"/>
-              <path d="M16.5 16.5L21 21" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
-            </svg>
-          ) : (
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
-              <path d="M8 5v14l11-7-11-7z" stroke="currentColor" strokeWidth="1.6" fill="currentColor" />
-            </svg>
-          )}
-        </button>
+        {loading ? (
+          <div style={loadingStyle}>Loading...</div>
+        ) : (
+          <Player src={src} />
+        )}
+        {!loading && (
+          <button
+            onClick={onToggle}
+            title={isMedium ? 'Switch to High' : 'Switch to Medium'}
+            aria-label={isMedium ? 'Switch to High' : 'Switch to Medium'}
+            style={toggleBtn}
+          >
+            {isMedium ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
+                <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="1.6"/>
+                <path d="M16.5 16.5L21 21" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
+                <path d="M8 5v14l11-7-11-7z" stroke="currentColor" strokeWidth="1.6" fill="currentColor" />
+              </svg>
+            )}
+          </button>
+        )}
         <button onClick={onClose} aria-label="Close" style={closeBtn}>
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
             <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
@@ -53,6 +59,15 @@ const innerStyle = {
   position: 'relative',
   width: '80%',
   maxWidth: 900
+}
+
+const loadingStyle = {
+  width: '100%',
+  height: 360,
+  display: 'grid',
+  placeItems: 'center',
+  color: '#fff',
+  background: '#000'
 }
 
 const toggleBtn = {

--- a/frontend/src/components/OverlayPlayer.jsx
+++ b/frontend/src/components/OverlayPlayer.jsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import Player from './Player'
+
+export default function OverlayPlayer({ open, role, src, onClose, onToggle }) {
+  if (!open) return null
+
+  const isMedium = role === 'medium'
+
+  return (
+    <div style={wrapStyle} onClick={onClose}>
+      <div style={innerStyle} onClick={e => e.stopPropagation()}>
+        <Player src={src} />
+        <button
+          onClick={onToggle}
+          title={isMedium ? 'Switch to High' : 'Switch to Medium'}
+          aria-label={isMedium ? 'Switch to High' : 'Switch to Medium'}
+          style={toggleBtn}
+        >
+          {isMedium ? (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
+              <circle cx="11" cy="11" r="6.5" stroke="currentColor" strokeWidth="1.6"/>
+              <path d="M16.5 16.5L21 21" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+            </svg>
+          ) : (
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
+              <path d="M8 5v14l11-7-11-7z" stroke="currentColor" strokeWidth="1.6" fill="currentColor" />
+            </svg>
+          )}
+        </button>
+        <button onClick={onClose} aria-label="Close" style={closeBtn}>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" role="img">
+            <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const wrapStyle = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  background: 'rgba(0,0,0,0.8)',
+  display: 'grid',
+  placeItems: 'center',
+  zIndex: 1000
+}
+
+const innerStyle = {
+  position: 'relative',
+  width: '80%',
+  maxWidth: 900
+}
+
+const toggleBtn = {
+  position: 'absolute',
+  top: 8,
+  right: 8,
+  width: 32,
+  height: 32,
+  display: 'grid',
+  placeItems: 'center',
+  border: 'none',
+  borderRadius: 4,
+  background: 'rgba(0,0,0,0.6)',
+  color: '#fff',
+  cursor: 'pointer'
+}
+
+const closeBtn = {
+  position: 'absolute',
+  top: 8,
+  right: 48,
+  width: 32,
+  height: 32,
+  display: 'grid',
+  placeItems: 'center',
+  border: 'none',
+  borderRadius: 4,
+  background: 'rgba(0,0,0,0.6)',
+  color: '#fff',
+  cursor: 'pointer'
+}


### PR DESCRIPTION
## Summary
- simplify camera grid items to show only video thumbnails
- add overlay player component with high/medium quality toggle
- open medium stream on grid click with ability to switch quality

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bcf5e2d3d48327b1f0122fb304a15e