### PR TITLE
fix: prevent immediate reaper stop after restart

### DIFF
--- a/backend/app/ffmpeg_manager.py
+++ b/backend/app/ffmpeg_manager.py
@@ -116,7 +116,8 @@ class LeaseTracker:
         now = time.time()
         with self._lock:
             self._last_seen[(cam_id, role)] = now
-            # do not set idle_since here; only set when last lease is released
+            # clear any prior idle time so reaper doesn't stop immediately
+            self._idle_since.pop((cam_id, role), None)
 
     def idle_for(self, cam_id: int, role: str) -> float:
         """Seconds since idle (no leases). 0 if not idle."""

--- a/backend/tests/test_leasetracker.py
+++ b/backend/tests/test_leasetracker.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+
+from backend.app.ffmpeg_manager import LeaseTracker
+
+def test_mark_activity_resets_idle():
+    lt = LeaseTracker()
+    cam_id, role = 1, "medium"
+    lease_id = lt.acquire(cam_id, role)
+    lt.release(cam_id, role, lease_id)
+    # ensure some measurable idle time
+    assert lt.idle_for(cam_id, role) >= 0
+    lt.mark_activity(cam_id, role)
+    assert lt.idle_for(cam_id, role) == 0


### PR DESCRIPTION
## Summary
- clear stored idle timestamp when ffmpeg role becomes active so reaper doesn't kill it immediately
- add regression test for LeaseTracker idle reset

## Testing
- `pytest -q` *(fails: OperationalError no such table: cameras)*
- `pytest backend/tests/test_leasetracker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd0fe1477883279fb9d65e2a98af72