### PR TITLE
Enable progressive playback of recordings

### DIFF
--- a/backend/app/ffmpeg_manager.py
+++ b/backend/app/ffmpeg_manager.py
@@ -363,6 +363,8 @@ class FFmpegManager:
             "-map", "0:v", "-map", "0:a?",
             "-c:v", "libx264", "-preset", "veryfast", "-crf", str(max(18, min(28, crf))),
             "-c:a", "aac", "-b:a", "128k",
+            # Place moov atom at the beginning so files are playable while downloading
+            "-movflags", "+faststart",
             "-f", "segment",
             "-segment_time", str(settings.RECORDING_SEGMENT_SEC),
             "-reset_timestamps", "1",


### PR DESCRIPTION
## Summary
- Allow progressive playback of recorded MP4 segments by enabling `faststart` movflag

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such table: cameras)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f4e8647883278b4d83a699e4df5f