### PR TITLE
Add recording clip export and saved videos list

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -30,5 +30,8 @@ if settings.RECORDINGS_ROOT:
 else:
     REC_DIR = MEDIA_ROOT / settings.REC_SUBDIR
 
+# Directory for user-saved clips from any camera
+CLIP_DIR = REC_DIR / "saved"
+
 DB_PATH = Path(settings.DB_PATH)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ import logging
 import time
 import subprocess
 import tempfile
+import shutil
 from sqlalchemy.orm import Session
 import threading
 from typing import List
@@ -488,7 +489,10 @@ def export_recording_segment(
         if not safe.endswith(".mp4"):
             safe += ".mp4"
         dest = CLIP_DIR / safe
-        tmp_path.replace(dest)
+        try:
+            shutil.move(str(tmp_path), dest)
+        except Exception as e:
+            raise HTTPException(500, f"Failed to save clip: {e}")
         return {"path": f"/api/saved/{dest.name}", "name": dest.name}
 
     download_name = body.name or "clip.mp4"

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -98,3 +98,16 @@ class RecordingFile(BaseModel):
     path: str          # API path like /api/recordings/<cam>/<date>/<hour>/<file>.mp4
     start_ts: float    # epoch seconds
     size_bytes: int
+
+# -------- Clip export --------
+
+class ClipExportRequest(BaseModel):
+    start: float
+    end: float
+    name: Optional[str] = None
+    save: bool = False
+
+class SavedVideo(BaseModel):
+    name: str
+    path: str
+    size_bytes: int

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -15,6 +15,18 @@ const API = {
     return fetch(`/api/cameras/${camId}/recordings/${date}`).then(r => r.json());
   },
 
+  savedVideos() {
+    return fetch('/api/saved').then(r => r.json());
+  },
+
+  exportRecording(path, { start, end, name, save }) {
+    return fetch(`${path}/export`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ start, end, name, save })
+    }).then(r => (save ? r.json() : r.blob()));
+  },
+
   // ADMIN — cameras
   getCamerasAdmin() {
     return fetch('/api/admin/cameras').then(r => r.json());

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -24,7 +24,10 @@ const API = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ start, end, name, save })
-    }).then(r => (save ? r.json() : r.blob()));
+    }).then(async r => {
+      if (!r.ok) throw new Error(await r.text());
+      return save ? r.json() : r.blob();
+    });
   },
 
   // ADMIN — cameras

--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import Hls from 'hls.js'
 
-export default function Player({ src, autoPlay=true }){
+const Player = forwardRef(({ src, autoPlay=true }, ref) => {
   const videoRef = useRef(null)
   useEffect(() => {
     if (!src || !videoRef.current) return
@@ -19,5 +19,8 @@ export default function Player({ src, autoPlay=true }){
       videoRef.current.src = src
     }
   }, [src])
+  useImperativeHandle(ref, () => videoRef.current)
   return <video ref={videoRef} controls autoPlay={autoPlay} playsInline style={{width:'100%', height:360, background:'#000'}} />
-}
+})
+
+export default Player

--- a/frontend/src/components/RecordingBrowser.jsx
+++ b/frontend/src/components/RecordingBrowser.jsx
@@ -1,13 +1,19 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import API from '../api'
 import Player from './Player'
 import DatePicker from './DatePicker'
 
 export default function RecordingBrowser({ cameras }){
+  const videoRef = useRef(null)
   const [camId, setCamId] = useState(cameras[0]?.id || null)
   const [date, setDate] = useState(() => new Date().toISOString().slice(0,10))
   const [files, setFiles] = useState([])
   const [selected, setSelected] = useState(null)
+  const [clipStart, setClipStart] = useState(null)
+  const [clipEnd, setClipEnd] = useState(null)
+  const [clipName, setClipName] = useState('')
+  const [showSaved, setShowSaved] = useState(false)
+  const [saved, setSaved] = useState([])
 
   useEffect(() => { if (cameras.length && !camId) setCamId(cameras[0].id) }, [cameras])
 
@@ -19,6 +25,32 @@ export default function RecordingBrowser({ cameras }){
   }
 
   useEffect(() => { load() }, [camId, date])
+  useEffect(() => { setClipStart(null); setClipEnd(null) }, [selected])
+
+  function markStart(){ if (videoRef.current) setClipStart(videoRef.current.currentTime) }
+  function markEnd(){ if (videoRef.current) setClipEnd(videoRef.current.currentTime) }
+
+  async function exportClip(save){
+    if (!selected || clipStart == null || clipEnd == null) return
+    const body = { start: clipStart, end: clipEnd, name: clipName, save }
+    const res = await API.exportRecording(selected, body)
+    if (save){
+      await loadSaved()
+    } else {
+      const blob = res
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = (clipName || 'clip') + '.mp4'
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+  }
+
+  async function loadSaved(){
+    const items = await API.savedVideos()
+    setSaved(items)
+  }
 
   return (
     <div className="panel">
@@ -29,7 +61,17 @@ export default function RecordingBrowser({ cameras }){
         <DatePicker value={date} onChange={setDate} />
       </div>
 
-      <Player src={selected} />
+      <Player src={selected} ref={videoRef} />
+
+      <div className="row" style={{gap:8, marginTop:8, flexWrap:'wrap', alignItems:'center'}}>
+        <button className="btn secondary" onClick={markStart}>Set Start</button>
+        <button className="btn secondary" onClick={markEnd}>Set End</button>
+        <span>Start: {clipStart?.toFixed(1) ?? '-'}</span>
+        <span>End: {clipEnd?.toFixed(1) ?? '-'}</span>
+        <input value={clipName} onChange={e=>setClipName(e.target.value)} placeholder="name" />
+        <button className="btn" onClick={()=>exportClip(false)}>Download</button>
+        <button className="btn" onClick={()=>exportClip(true)}>Save</button>
+      </div>
 
       <div style={{marginTop:12, display:'grid', gridTemplateColumns:'repeat(auto-fill, minmax(120px, 1fr))', gap:8}}>
         {files.map(f => (
@@ -38,6 +80,22 @@ export default function RecordingBrowser({ cameras }){
           </button>
         ))}
         {!files.length && <div>No recordings for this date.</div>}
+      </div>
+
+      <div style={{marginTop:16}}>
+        <button className="btn secondary" onClick={async ()=>{if(!showSaved){await loadSaved()} setShowSaved(!showSaved)}}>
+          {showSaved ? 'Hide Saved Videos' : 'View Saved Videos'}
+        </button>
+        {showSaved && (
+          <div style={{marginTop:8}}>
+            {saved.map(s => (
+              <div key={s.path}>
+                <a href={s.path} target="_blank" rel="noopener">{s.name}</a>
+              </div>
+            ))}
+            {saved.length === 0 && <div>No saved videos.</div>}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/RecordingBrowser.jsx
+++ b/frontend/src/components/RecordingBrowser.jsx
@@ -33,17 +33,21 @@ export default function RecordingBrowser({ cameras }){
   async function exportClip(save){
     if (!selected || clipStart == null || clipEnd == null) return
     const body = { start: clipStart, end: clipEnd, name: clipName, save }
-    const res = await API.exportRecording(selected, body)
-    if (save){
-      await loadSaved()
-    } else {
-      const blob = res
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = (clipName || 'clip') + '.mp4'
-      a.click()
-      URL.revokeObjectURL(url)
+    try {
+      const res = await API.exportRecording(selected, body)
+      if (save){
+        await loadSaved()
+      } else {
+        const blob = res
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = (clipName || 'clip') + '.mp4'
+        a.click()
+        URL.revokeObjectURL(url)
+      }
+    } catch (e) {
+      alert(`Export failed: ${e.message}`)
     }
   }
 


### PR DESCRIPTION
## Summary
- allow selecting a time span in a recording and export it
- support saving exported clips server-side and listing saved videos
- update player to expose ref and recording browser to manage clips

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c5382cb3a48327b2d1ae2bff9b7143