### PR TITLE
Align recordings to fixed periods

### DIFF
--- a/backend/app/recordings.py
+++ b/backend/app/recordings.py
@@ -4,8 +4,10 @@ import os, time, re
 from typing import List
 from .config import REC_DIR
 
-# Filenames like: YYYY-MM-DD_HH-MM-SS.mp4
-FNAME_RE = re.compile(r"(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2})\.mp4$")
+# Filenames like: YYYY-MM-DD_HH-MM-SS[_NNN].mp4
+FNAME_RE = re.compile(
+    r"(\d{4}-\d{2}-\d{2})_(\d{2})-(\d{2})-(\d{2})(?:_(\d+))?\.mp4$"
+)
 
 def list_recordings(camera: str, date_str: str) -> List[dict]:
     base = REC_DIR / camera / date_str
@@ -20,10 +22,9 @@ def list_recordings(camera: str, date_str: str) -> List[dict]:
                 continue
             full = Path(hour_dir) / f
             try:
-                ts = time.mktime(time.strptime(
-                    FNAME_RE.search(f).group(0).replace('.mp4',''),
-                    "%Y-%m-%d_%H-%M-%S"
-                ))
+                m = FNAME_RE.search(f)
+                ts_str = f"{m.group(1)}_{m.group(2)}-{m.group(3)}-{m.group(4)}"
+                ts = time.mktime(time.strptime(ts_str, "%Y-%m-%d_%H-%M-%S"))
             except Exception:
                 ts = full.stat().st_mtime
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -17,9 +17,10 @@ def api_client(tmp_path, monkeypatch):
     monkeypatch.setenv("DB_PATH", str(db_path))
 
     # Reload configuration and database modules so they pick up the new DB_PATH
-    from backend.app import config, db, ffmpeg_manager, main
+    from backend.app import config, db, ffmpeg_manager, main, models
     importlib.reload(config)
     importlib.reload(db)
+    importlib.reload(models)
     importlib.reload(ffmpeg_manager)
     importlib.reload(main)
 


### PR DESCRIPTION
## Summary
- Align FFmpeg recording segments to start at period boundaries and avoid overwriting existing files
- Update recording listing to handle suffixed filenames
- Reload models in API test fixture for correct database setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c55d95f84c832790209fb3587c2727