### PR TITLE
Improve recording browser layout

### DIFF
--- a/frontend/src/components/Player.jsx
+++ b/frontend/src/components/Player.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import Hls from 'hls.js'
 
-const Player = forwardRef(({ src, autoPlay=true }, ref) => {
+const Player = forwardRef(({ src, autoPlay=true, style }, ref) => {
   const videoRef = useRef(null)
   useEffect(() => {
     if (!src || !videoRef.current) return
@@ -20,7 +20,15 @@ const Player = forwardRef(({ src, autoPlay=true }, ref) => {
     }
   }, [src])
   useImperativeHandle(ref, () => videoRef.current)
-  return <video ref={videoRef} controls autoPlay={autoPlay} playsInline style={{width:'100%', height:360, background:'#000'}} />
+  return (
+    <video
+      ref={videoRef}
+      controls
+      autoPlay={autoPlay}
+      playsInline
+      style={{ width: '100%', height: 360, background: '#000', objectFit: 'cover', ...style }}
+    />
+  )
 })
 
 export default Player


### PR DESCRIPTION
## Summary
- Allow Player component to accept custom styles
- Expand recordings video to fill screen and move saved clips to right sidebar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6b656e3408327973e952841eae1ba